### PR TITLE
Updates numpy loss tensor accessor. Previously broken.

### DIFF
--- a/The Annotated Transformer.ipynb
+++ b/The Annotated Transformer.ipynb
@@ -1260,7 +1260,7 @@
     "        if self.opt is not None:\n",
     "            self.opt.step()\n",
     "            self.opt.optimizer.zero_grad()\n",
-    "        return loss.data[0] * norm"
+    "        return loss.item() * norm"
    ]
   },
   {


### PR DESCRIPTION
The current notebook is broken with recent versions of torch.  Error is:

```
IndexError: invalid index of a 0-dim tensor. Use `tensor.item()` in Python or `tensor.item<T>()` in C++ to convert a 0-dim tensor to a number
```
