### PR TITLE
Removing the unnecessary import statement

### DIFF
--- a/AnnotatedTransformer.ipynb
+++ b/AnnotatedTransformer.ipynb
@@ -2405,7 +2405,6 @@
    "outputs": [],
    "source": [
     "def train_model(vocab_src, vocab_tgt, spacy_de, spacy_en, config):\n",
-    "    from the_annotated_transformer import train_worker\n",
     "    if config[\"distributed\"]:\n",
     "        ngpus = torch.cuda.device_count()\n",
     "        os.environ[\"MASTER_ADDR\"] = \"localhost\"\n",


### PR DESCRIPTION
Remove the "from the_annotated_transformer import train_worker", you can't call this in the notebook since the function is already in the notebook.