### PR TITLE
use biased estimate of std in layernorm as in the original paper

### DIFF
--- a/the_annotated_transformer.py
+++ b/the_annotated_transformer.py
@@ -323,7 +323,7 @@ class LayerNorm(nn.Module):
 
     def forward(self, x):
         mean = x.mean(-1, keepdim=True)
-        std = x.std(-1,correction=0,keepdim=True)
+        std = x.std(-1,unbiased=False,keepdim=True)
         return self.a_2 * (x - mean) / (std + self.eps) + self.b_2
 
 

--- a/the_annotated_transformer.py
+++ b/the_annotated_transformer.py
@@ -323,7 +323,7 @@ class LayerNorm(nn.Module):
 
     def forward(self, x):
         mean = x.mean(-1, keepdim=True)
-        std = x.std(-1, keepdim=True)
+        std = x.std(-1,correction=0,keepdim=True)
         return self.a_2 * (x - mean) / (std + self.eps) + self.b_2
 
 


### PR DESCRIPTION
The original [paper](https://arxiv.org/pdf/1607.06450.pdf) computes a biased estimate of sample standard deviation. However, by default, `torch.Tensor.std()` uses an unbiased estimate [Ref](https://pytorch.org/docs/1.11/generated/torch.Tensor.std.html?highlight=torch%20std#torch.Tensor.std). Therefore, it is necessary to use  `torch.Tensor.std(-1,unbiased=False)`. Moreover, the class `nn.LayerNorm()` uses biased estimate as well. Though it does not make much difference for large dim, following the definition given in the cited paper is more appropriate.

For PyTorch>=2.0, use `torch.Tensor.std(-1,correction=0)`. 